### PR TITLE
Jf/update readme

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,10 +1,14 @@
 # Windows
-PATH_PREFIX_EDGE=C:/Dev/iotedge/crate/localstorageCrateDBEdgeSolution
-PATH_PREFIX_STORAGE=C:/Dev/docker/mounts
+#PATH_PREFIX_EDGE=C:/Dev/iotedge/crate/localstorageCrateDBEdgeSolution
+#PATH_PREFIX_STORAGE=C:/Dev/docker/mounts
 
 # OSX
 #PATH_PREFIX_EDGE=/Users/jodok/sandbox/azure-iotedge-cratedb-sample/storage/edge
 #PATH_PREFIX_STORAGE=/Users/jodok/sandbox/azure-iotedge-cratedb-sample/storage
+
+# Vagrant
+PATH_PREFIX_EDGE=/mnt/sample
+PATH_PREFIX_STORAGE=/mnt/sample
 
 cr8playground_username=<username>
 cr8playground_password=<password>

--- a/README.md
+++ b/README.md
@@ -55,9 +55,12 @@ This setup step should be done in your laptop, and will create the information i
 1. Per default this sample uses all nodes from the [OPC-UA Server simulation](https://github.com/Azure-Samples/iot-edge-opc-plc). If you want to change the setup, just edit the `publishednodes.json` file in the folder `appdata`
 2. Edit the files `deployment.template.json` and `deployment.debug.template.json` by changing the publisher's data folder from `C:/Dev/iotedge/crate/localstorageCrateDBEdgeSolution` to the directory you've downloaded the source repository on your local disk.
 
+## Connecting to CrateDB
+The Vagrantfile binds the CrateDB on the edge device port 4200 to the port 4200 in your system. Browse to `http://localhost:4200` and you will find the CrateDB Admin UI.
+
 
 ## Connecting to Grafana
-The Vagrantfile binds the grafana port on the edge device 3000 to the port 33000 in your system. Browse to `http://localhost:33000` and you will find the login page. Use `admin` as username and password.
+The Vagrantfile binds the grafana on the edge device port 3000 to the port 3000 in your system. Browse to `http://localhost:3000` and you will find the login page. Use `admin` as username and password.
 
 
 # Running the sample

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This approach makes the set-up experience more streamlined.
 1. Checkout this repo `git clone https://github.com/crate/azure-iotedge-cratedb-sample.git`
 2. Install [Vagrant](https://www.vagrantup.com/downloads.html).
 3. Install [Visual Studio Code](https://code.visualstudio.com/download).
-4. Install extensions for Visual Studio: (On the Visual Studio Code: Menu -> Preferences -> Extensions)
+4. Install extensions for Visual Studio Code: (On the Visual Studio Code: Menu -> Preferences -> Extensions)
     1. Azure IoT Hub Toolkit
     2. Azure IoT Edge
     3. Vagrant
@@ -26,12 +26,12 @@ This approach makes the set-up experience more streamlined.
 7. Create a folder `crate` in the project directory. For me, it is `/gn/git/azure-iotedge-cratedb-sample/crate`.
 8. Follow the instructions under 'Configuring the local database'.
 9. Create an IoT Hub (S1) on Azure. You'll need to wait for it to be in an active state, it could take a while.
-10. After your IoT hub has started, you can use Visual Studio integration to connect to it.
-11. In Visual Studio (or on the Azure Portal), you can create a new test Edge Device.
-12. Right click on the device and select “Copy Device Connection String” from the Menu.   
+10. After your IoT hub has started, you can use Visual Studio Code integration to connect to it.
+11. In Visual Studio Code (or on the Azure Portal), you can create a new IoT Edge Device.
+12. Right click on the device and select “Copy Device Connection String” from the Menu.
 13. Go to the Vagrant folder of the project, for me it is `cd /gn/git/azure-iotedge-cratedb-sample/vagrant`.
 14. Modify the `config.template.yaml` to use your Device Connection String and rename it to `config.yaml`.
-15. Right click on `deployment.template.json` and click on 'Build IoT Edge Module'.
+15. Right click on `deployment.template.json` and click on 'Build IoT Edge Solution'.
 16. Go to the config folder, right click on `deployment.amd64.json` and click on 'Create Deployment for Single Device'.
 15. In your terminal, start Vagrant by `vagrant up`.
 16. Open the shh by running `vagrant ssh`.

--- a/README.md
+++ b/README.md
@@ -31,11 +31,12 @@ This approach makes the set-up experience more streamlined.
 12. Right click on the device and select “Copy Device Connection String” from the Menu.
 13. Go to the Vagrant folder of the project, for me it is `cd /gn/git/azure-iotedge-cratedb-sample/vagrant`.
 14. Modify the `config.template.yaml` to use your Device Connection String and rename it to `config.yaml`.
-15. Right click on `deployment.template.json` and click on 'Build IoT Edge Solution'.
-16. Go to the config folder, right click on `deployment.amd64.json` and click on 'Create Deployment for Single Device'.
-15. In your terminal, start Vagrant by `vagrant up`.
-16. Open the shh by running `vagrant ssh`.
-17. Restart the service inside the VM by `sudo systemctl restart iotedge`.
+15. Copy the contents of `.env.template` into a new file `.env`. The default settings work out of the box for the vagrant box.
+16. Right click on `deployment.template.json` and click on 'Build IoT Edge Solution'.
+17. Go to the config folder, right click on `deployment.amd64.json` and click on 'Create Deployment for Single Device'.
+18. In your terminal, start Vagrant by `vagrant up`.
+19. Open the shh by running `vagrant ssh`.
+20. Restart the service inside the VM by `sudo systemctl restart iotedge`.
 
 
 ## Configuring the local database

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ This approach makes the set-up experience more streamlined.
 Before starting to deploy the sample to the edge device, the local CrateDB used in the sample has to be created first. An existing CrateDB in the local network could be used, too, but this sample uses CrateDB running in a container on the same device as the Azure IoT Edge runtime. 
 This setup step should be done in your laptop, and will create the information in a data folder. This data folder is then shared with the Edge module, so the tables will be there. (that's why we start and stop the container after running the SQL)
 
-1. Create a folder on the disk for the CrateDB database files under the `crate` folder that you created above in step 7. For me, it is `/gn/git/azure-iotedge-cratedb-sample/crate/data`. 
-2. Run CrateDB locally from the command line by using `docker run -p "4200:4200" -d --rm --name cratedb -v /gn/git/azure-iotedge-cratedb-sample/crate/data:/data crate` and replace it with the location for the folder you have created in step 1.
+1. Create a folder on the disk for the CrateDB database files under the `crate` folder that you created above in step 7. For me, it is `/gn/git/azure-iotedge-cratedb-sample/crate/data`.
+2. Run CrateDB locally from the command line by using `docker run -p "4200:4200" -d --rm --name cratedb -v /gn/git/azure-iotedge-cratedb-sample/crate/data:/data crate:4.1.2` and replace it with the location for the folder you have created in step 1.
 3. Open a web browser with `http://localhost:4200` and go to the CrateDB Admin UI console.
 4. Create the tables and the user by executing all SQL Statements in the file `./scripts/database_setup/createTable.sql`.
 5. Stop the container with `docker container stop cratedb`.

--- a/README.md
+++ b/README.md
@@ -61,8 +61,3 @@ The Vagrantfile binds the CrateDB on the edge device port 4200 to the port 4200 
 
 ## Connecting to Grafana
 The Vagrantfile binds the grafana on the edge device port 3000 to the port 3000 in your system. Browse to `http://localhost:3000` and you will find the login page. Use `admin` as username and password.
-
-
-# Running the sample
-
-Easiest way to run the sample is by using Visual Studio Code and Vagrant.

--- a/deployment.template.json
+++ b/deployment.template.json
@@ -138,7 +138,7 @@
             "status": "running",
             "restartPolicy": "always",
             "settings": {
-              "image": "crate:3.3.5",
+              "image": "crate:4.1.2",
               "createOptions": {
                 "Hostname" : "cratedb",
                 "HostConfig": {

--- a/scripts/local_setup/docker-compose.yml
+++ b/scripts/local_setup/docker-compose.yml
@@ -9,7 +9,7 @@ version: '3.5'
 
 services: 
   cratedb:
-    image: crate:3.2.4
+    image: crate:4.1.2
     container_name: cratedb
     networks: 
       - crate-net

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -32,8 +32,8 @@ Vagrant.configure("2") do |config|
   # accessing "localhost:8080" will access port 80 on the guest machine.
   # config.vm.network "forwarded_port", guest: 80, host: 8080
   #config.vm.network "forwarded_port", guest: 5000, host: 5000
-  config.vm.network "forwarded_port", guest: 4200, host: 44200
-  config.vm.network "forwarded_port", guest: 3000, host: 33000
+  config.vm.network "forwarded_port", guest: 4200, host: 4200
+  config.vm.network "forwarded_port", guest: 3000, host: 3000
 
   # Create a private network, which allows host-only access to the machine
   # using a specific IP.


### PR DESCRIPTION
Changes:
* adds the required paths to the .env.template for using the vagrant VM as IoT Edge device
* bump CrateDB to latest version 
* make sure that the same CrateDB version is used everywhere (there was a problem with a version mismatch between used CrateDB on edge device and the CrateDB version used in step `Configuring the local database`)
* use standard ports for Grafana and CrateDB
* add missing steps to the instructions